### PR TITLE
Override FetchContent flag to make sure that content is populated

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
 		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+		-DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
 		$(BUILD_TESTING_ARG)
 
 override_dh_auto_build:


### PR DESCRIPTION
Relates to https://github.com/Fields2Cover/Fields2Cover/issues/136

Override  -DFETCHCONTENT_FULLY_DISCONNECTED=OFF to allow FetchContent to function.

Derived from/Legitimised by https://github.com/ros2-gbp/rosbag2-release/pull/10/files